### PR TITLE
basic permissions

### DIFF
--- a/app/views/merge_request_links/_box.html.erb
+++ b/app/views/merge_request_links/_box.html.erb
@@ -1,10 +1,12 @@
-<% merge_requests = MergeRequest.find_all_by_issue(@issue) %>
+<% if User.current.allowed_to?(:browse_repository, @project) %>
+  <% merge_requests = MergeRequest.find_all_by_issue(@issue) %>
 
-<% if merge_requests.present? %>
-<div id="issue-merge-requests">
-  <h3><%= l(:mrl_label_associated_merge_requests) %></h3>
-  <%= render(partial: 'merge_request_links/merge_request_link',
-             collection: MergeRequest.find_all_by_issue(@issue),
-             as: :merge_request) %>
-</div>
+  <% if merge_requests.present? %>
+  <div id="issue-merge-requests">
+    <h3><%= l(:mrl_label_associated_merge_requests) %></h3>
+    <%= render(partial: 'merge_request_links/merge_request_link',
+               collection: MergeRequest.find_all_by_issue(@issue),
+               as: :merge_request) %>
+  </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Use redmine built-in `:browse_repository` permissions to view the MergeRequest box. This hides the box from external users who are not allowed to view the "repositories" tab in the project.

However, this is kind of a hacky solution for permission handling.
There's better ways, see for example https://github.com/paginagmbh/redmine_silencer/blob/master/init.rb#L12 to add a new permission for Roles.