### PR TITLE
Add project module and permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Finally, restart your webserver.
 
 Create a webhook in GitLab or GitHub as described here:
 
+### Redmine Administration
+
+To display associated merge requests on issue pages:
+
+* Add the "View associated merge requests" permission to one or more
+  roles.
+
+* Enable the "Merge request links" project module.
+
 ### GitLab
 
 * Go to either the webhook page of a project (Settings > Integration)

--- a/app/views/merge_request_links/_box.html.erb
+++ b/app/views/merge_request_links/_box.html.erb
@@ -1,4 +1,4 @@
-<% if User.current.allowed_to?(:browse_repository, @project) %>
+<% if User.current.allowed_to?(:view_associated_merge_requests, @project) %>
   <% merge_requests = MergeRequest.find_all_by_issue(@issue) %>
 
   <% if merge_requests.present? %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,3 +1,5 @@
 de:
+  project_module_merge_request_links: Merge Request Verweise
+  permission_view_associated_merge_requests: Zugehörige Merge Requests sehen
   mrl_label_associated_merge_requests: Zugehörige Merge Requests
   mrl_label_by: von

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,5 @@
 en:
+  project_module_merge_request_links: Merge request links
+  permission_view_associated_merge_requests: View associated merge requests
   mrl_label_associated_merge_requests: Associated Merge Requests
   mrl_label_by: by

--- a/init.rb
+++ b/init.rb
@@ -9,6 +9,10 @@ Redmine::Plugin.register :redmine_merge_request_links do
   author_url 'https://github.com/tf'
 
   requires_redmine version_or_higher: '3.0'
+
+  project_module :merge_request_links do
+    permission :view_associated_merge_requests, {}
+  end
 end
 
 require 'redmine_merge_request_links'


### PR DESCRIPTION
Allow fine grain control who can see associated merge requests and for which projects they are displayed.

refs #7 