### PR TITLE
Support GitLab's long form Redmine issue links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://www.phusionpassenger.com/library/indepth/environment_variables.html
 Finally, restart your webserver.
 
 
-## Usage
+## Configuration
 
 Create a webhook in GitLab or GitHub as described here:
 
@@ -82,7 +82,7 @@ Create a webhook in GitLab or GitHub as described here:
 
 * Click "Add webhook".
 
-### Redmine Administration
+### Redmine
 
 To display associated merge requests on issue pages:
 
@@ -90,6 +90,13 @@ To display associated merge requests on issue pages:
   roles.
 
 * Enable the "Merge request links" project module.
+
+
+## Usage
+
+Create a merge request and reference a Redmine issue either in the
+form `#123` or `REDMINE-123`. See a link to the merge request appear
+on the issue's Redmine page.
 
 
 ## Known Issues

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -18,7 +18,7 @@ class MergeRequest < ActiveRecord::Base
 
   private
 
-  ISSUE_ID_REGEXP = /(?:[^a-z]|\A)#(\d+)/
+  ISSUE_ID_REGEXP = /(?:[^a-z]|\A)(?:#|REDMINE-)(\d+)/
 
   def scan_description_for_issue_ids
     self.issues = mentioned_issue_ids.map do |match|

--- a/test/unit/merge_request_test.rb
+++ b/test/unit/merge_request_test.rb
@@ -70,6 +70,15 @@ class MergeRequestTest < ActiveSupport::TestCase
     assert_includes(merge_request.issues, issue)
   end
 
+  def test_supports_issue_id_with_redmine_prefix
+    issue = Issue.last
+    merge_request = MergeRequest.create!
+
+    merge_request.update!(description: "see REDMINE-#{issue.id}")
+
+    assert_includes(merge_request.issues, issue)
+  end
+
   def test_issue_id_can_be_at_beginning_of_description
     issue = Issue.last
     merge_request = MergeRequest.create!


### PR DESCRIPTION
GitLab supports referencing Redmine issues by strings of the form
`REDMINE-123`. Gitlab allows arbitrary all caps prefixes. For now we
only allow the `REDMINE` prefix since this is the convention we are currently
using internally. This could become a setting at some point in the
future.