### PR TITLE
Set state of PR to merged if merged flag is present

### DIFF
--- a/lib/redmine_merge_request_links/event_handlers/github.rb
+++ b/lib/redmine_merge_request_links/event_handlers/github.rb
@@ -25,13 +25,18 @@ module RedmineMergeRequestLinks
       def parse_params(params)
         params
           .require(:pull_request)
-          .permit(:state, :html_url, :title, :body, :number,
+          .permit(:state, :merged, :html_url, :title, :body, :number,
                   user: :login,
                   base: { repo: :full_name }).tap do |attributes|
 
+          merged = attributes.delete(:merged)
           user = attributes.delete(:user) || {}
           base = attributes.delete(:base) || {}
           repo = base.fetch(:repo, {})
+
+          if attributes[:state] == 'closed' && merged
+            attributes[:state] = 'merged'
+          end
 
           attributes[:provider] = 'github'
           attributes[:url] = attributes.delete(:html_url)

--- a/test/functional/merge_requests_controller_test.rb
+++ b/test/functional/merge_requests_controller_test.rb
@@ -316,6 +316,36 @@ class MergeRequestsControllerTest < ActionController::TestCase
     assert_includes(merge_request.issues, issue)
   end
 
+  def test_sets_state_to_merged_if_closed_and_merged
+    url = 'https://github.com/Codertocat/Hello-World/pull/1'
+
+    payload = {
+      pull_request: {
+        html_url: url,
+        title: 'Some pull request',
+        state: 'closed',
+        merged: true,
+        number: 12,
+        user: {
+          login: 'someuser'
+        },
+        base: {
+          repo: {
+            full_name: 'group/project'
+          }
+        }
+      }
+    }
+    request.headers['X-GitHub-Event'] = 'pull_request'
+    request.headers['X-Hub-Signature'] = hub_signature(payload)
+    post(:event, payload)
+
+    assert_response :success
+
+    merge_request = MergeRequest.where(url: url).first
+    assert_equal 'merged', merge_request.state
+  end
+
   def test_responds_with_bad_request_if_unknown_event
     post(:event)
 


### PR DESCRIPTION
GitHub always reports "closed" as state. There is a separate flag
which indicates, whether the PR was merged or closed without merging.