### PR TITLE
Run tests also against Redmine 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 sudo: required
 
+env:
+  - REDMINE_VERSION: 3.4
+  - REDMINE_VERSION: 4.0
+
 services:
   - docker
 
 before_install:
-  - bin/build
+  - bin/build --build-arg REDMINE_VERSION=$REDMINE_VERSION
 
 script:
   - bin/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM redmine:3.4.6
+ARG REDMINE_VERSION=3.4
+FROM redmine:${REDMINE_VERSION}
 
 COPY patches/view_hook_issues_show_after_details.patch /
 RUN git apply /view_hook_issues_show_after_details.patch

--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t redmine_merge_request_links_test .
+docker build -t redmine_merge_request_links_test $* .

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class IssuesControllerTest < ActionController::TestCase
+  include RedmineMergeRequestLinks::RequestTestHelperCompat
+
   fixtures :projects,
            :users,
            :roles,

--- a/test/functional/merge_requests_controller_test.rb
+++ b/test/functional/merge_requests_controller_test.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class MergeRequestsControllerTest < ActionController::TestCase
+  include RedmineMergeRequestLinks::RequestTestHelperCompat
+
   TOKEN = 'secret'
   MERGE_REQUEST_URL = 'https://gitlab.example.com/project/merge_requests/1'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,33 @@
+# For unknown reasons, column information is not reloaded correctly
+# when running the `db:migrate` and `redmine:plugins:test` tasks in
+# one `rake` call. Reset manually.
+if defined?(ActiveRecord)
+  ActiveRecord::Base.descendants.each(&:reset_column_information)
+end
+
 # Suppress warnings
 $VERBOSE = false
 
 # Load the Redmine helper
 require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
+
+Rails.logger.level = :warn
+
+module RedmineMergeRequestLinks
+  module RequestTestHelperCompat
+    def get(action, parameters = {})
+      super(action, compatible_request_options(parameters))
+    end
+
+    def post(action, parameters = {})
+      super(action, compatible_request_options(parameters))
+    end
+
+    private
+
+    def compatible_request_options(parameters)
+      return parameters if Rails.version < '5.0'
+      { params: parameters }
+    end
+  end
+end


### PR DESCRIPTION
* Use compat helper for request specs since Rails 5 requires passing
  parameters in `params` option.

* Add build arg for Redmine image to Dockerfile and run multiple
  Travis jobs.

* Work around issue where column information was not reloaded
  correctly when running migrations and tests in a single `rake` call.

* Reset log level to `warn` during test execution. Migrations are
  still noisy.