### PR TITLE
Gitea support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@
 
 [![Build Status](https://travis-ci.org/tf/redmine_merge_request_links.svg?branch=master)](https://travis-ci.org/tf/redmine_merge_request_links)
 
-Display links to associated GitLab merge requests and GitHub pull
-requests on Redmine's issue page.
+Display links to associated merge requests and pull requests on Redmine's issue page.
 
-Intercepts webhooks and parses merge request descriptions for
-mentioned issue ids.
+Intercepts webhooks and parses merge request descriptions for mentioned issue ids.
+
+The following platforms are supported:
+
+* GitHub
+* GitLab
+* Gitea
 
 
 ## Requirements
 
 * Redmine 3 (tested with 3.4.6)
-
 
 ## Installation
 
@@ -82,6 +85,24 @@ Create a webhook in GitLab or GitHub as described here:
 
 * Click "Add webhook".
 
+### Gitea
+
+* Go to the webhook page of a project or organization.
+
+* Enter the URL of your Redmine instance
+  `https://redmine.example.com/merge_requests/event`.
+
+* Select `application/json` as content type.
+
+* Enter the secret token you defined in environment variable
+  `REDMINE_MERGE_REQUEST_LINKS_GITEA_WEBHOOK_TOKEN`.
+
+* Choose "Custom events...".
+
+* Check the "Pull requests" event.
+
+* Click "Add webhook".
+
 ### Redmine
 
 To display associated merge requests on issue pages:
@@ -101,7 +122,7 @@ on the issue's Redmine page.
 
 ## Known Issues
 
-* Gitlab only passes the author id as part of the merge request
+* GitLab only passes the author id as part of the merge request
   webhook not a display name. It does include the username of the user
   whose action triggered the webhook, though. To prevent having to
   fetch the author name in a separate REST API call, this username is

--- a/lib/redmine_merge_request_links.rb
+++ b/lib/redmine_merge_request_links.rb
@@ -3,10 +3,12 @@ require 'redmine_merge_request_links/hooks'
 module RedmineMergeRequestLinks
   github_token = ENV['REDMINE_MERGE_REQUEST_LINKS_GITHUB_WEBHOOK_TOKEN']
   gitlab_token = ENV['REDMINE_MERGE_REQUEST_LINKS_GITLAB_WEBHOOK_TOKEN']
+  gitea_token  = ENV['REDMINE_MERGE_REQUEST_LINKS_GITEA_WEBHOOK_TOKEN']
 
   mattr_accessor :event_handlers
   self.event_handlers = [
     RedmineMergeRequestLinks::EventHandlers::Github.new(token: github_token),
-    RedmineMergeRequestLinks::EventHandlers::Gitlab.new(token: gitlab_token)
+    RedmineMergeRequestLinks::EventHandlers::Gitlab.new(token: gitlab_token),
+    RedmineMergeRequestLinks::EventHandlers::Gitea.new(token: gitea_token)
   ]
 end

--- a/lib/redmine_merge_request_links.rb
+++ b/lib/redmine_merge_request_links.rb
@@ -7,8 +7,8 @@ module RedmineMergeRequestLinks
 
   mattr_accessor :event_handlers
   self.event_handlers = [
+    RedmineMergeRequestLinks::EventHandlers::Gitea.new(token: gitea_token),
     RedmineMergeRequestLinks::EventHandlers::Github.new(token: github_token),
-    RedmineMergeRequestLinks::EventHandlers::Gitlab.new(token: gitlab_token),
-    RedmineMergeRequestLinks::EventHandlers::Gitea.new(token: gitea_token)
+    RedmineMergeRequestLinks::EventHandlers::Gitlab.new(token: gitlab_token)
   ]
 end

--- a/lib/redmine_merge_request_links/event_handlers/gitea.rb
+++ b/lib/redmine_merge_request_links/event_handlers/gitea.rb
@@ -1,0 +1,42 @@
+module RedmineMergeRequestLinks
+  module EventHandlers
+    class Gitea
+      def initialize(token:)
+        @token = token
+      end
+
+      def matches?(request)
+        request.headers['X-Gitea-Event'] == 'pull_request'
+      end
+
+      def verify(request)
+      end
+
+      def parse_params(params)
+        params
+          .require(:pull_request)
+          .permit(:state, :merged, :html_url, :title, :body, :number,
+                  user: :login,
+                  base: { repo: :full_name }).tap do |attributes|
+
+          merged = attributes.delete(:merged)
+          user = attributes.delete(:user) || {}
+          base = attributes.delete(:base) || {}
+          repo = base.fetch(:repo, {})
+
+          if attributes[:state] == 'closed' && merged
+            attributes[:state] = 'merged'
+          end
+
+          attributes[:provider] = 'gitea'
+          attributes[:url] = attributes.delete(:html_url)
+          attributes[:description] = attributes.delete(:body)
+          attributes[:author_name] = "@#{user[:login]}"
+
+          attributes[:display_id] =
+            "#{repo[:full_name]}##{attributes.delete(:number)}"
+        end
+      end
+    end
+  end
+end

--- a/lib/redmine_merge_request_links/event_handlers/gitea.rb
+++ b/lib/redmine_merge_request_links/event_handlers/gitea.rb
@@ -14,7 +14,7 @@ module RedmineMergeRequestLinks
         payload = request.body.read
 
         signature =
-          'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'),
+          'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'),
                                             @token,
                                             payload)
 

--- a/lib/redmine_merge_request_links/event_handlers/gitea.rb
+++ b/lib/redmine_merge_request_links/event_handlers/gitea.rb
@@ -10,6 +10,16 @@ module RedmineMergeRequestLinks
       end
 
       def verify(request)
+        request.body.rewind
+        payload = request.body.read
+
+        signature =
+          'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'),
+                                            @token,
+                                            payload)
+
+        Rack::Utils.secure_compare(signature,
+                                   request.headers['X-Gitea-Signature'])
       end
 
       def parse_params(params)

--- a/lib/redmine_merge_request_links/event_handlers/gitea.rb
+++ b/lib/redmine_merge_request_links/event_handlers/gitea.rb
@@ -13,8 +13,7 @@ module RedmineMergeRequestLinks
         request.body.rewind
         payload = request.body.read
 
-        signature =
-          'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'),
+        signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'),
                                             @token,
                                             payload)
 

--- a/test/functional/merge_requests_controller_test.rb
+++ b/test/functional/merge_requests_controller_test.rb
@@ -378,7 +378,28 @@ class MergeRequestsControllerTest < ActionController::TestCase
     assert_equal 'Some pull request', merge_request.title
     assert_equal 'group/project#12', merge_request.display_id
     assert_equal '@someuser', merge_request.author_name
-    assert_equal 'github', merge_request.provider
+    assert_equal 'gitea', merge_request.provider
+  end
+
+  def test_responds_with_forbidden_if_gitea_signature_is_incorrect
+    request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-Gitea-Signature'] = 'wrong'
+    post(:event, pull_request: {
+           html_url: 'https://gitea.com/Codertocat/Hello-World/pull/1',
+           title: 'Some pull request',
+           state: 'closed',
+           number: 12,
+           user: {
+             login: 'someuser'
+           },
+           base: {
+             repo: {
+               full_name: 'group/project'
+             }
+           }
+         })
+
+    assert_response :forbidden
   end
 
   def test_associates_issues_mentioned_in_gitea_pr_body

--- a/test/functional/merge_requests_controller_test.rb
+++ b/test/functional/merge_requests_controller_test.rb
@@ -522,7 +522,7 @@ class MergeRequestsControllerTest < ActionController::TestCase
   end
 
   def gitea_signature(payload)
-    'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'),
+    OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'),
                                       TOKEN,
                                       payload.to_query)
   end

--- a/test/functional/merge_requests_controller_test.rb
+++ b/test/functional/merge_requests_controller_test.rb
@@ -371,8 +371,8 @@ class MergeRequestsControllerTest < ActionController::TestCase
     request.headers['X-Gitea-Event'] = 'pull_request'
     request.headers['X-GitHub-Event'] = 'pull_request'
     request.headers['X-Gogs-Event'] = 'pull_request'
-    request.headers['X-Gitea-Signature'] = hub_signature(payload)
-    request.headers['X-Gogs-Signature'] = hub_signature(payload)
+    request.headers['X-Gitea-Signature'] = gitea_signature(payload)
+    request.headers['X-Gogs-Signature'] = gitea_signature(payload)
 
     post(:event, payload)
 
@@ -434,8 +434,8 @@ class MergeRequestsControllerTest < ActionController::TestCase
     request.headers['X-Gitea-Event'] = 'pull_request'
     request.headers['X-GitHub-Event'] = 'pull_request'
     request.headers['X-Gogs-Event'] = 'pull_request'
-    request.headers['X-Gitea-Signature'] = hub_signature(payload)
-    request.headers['X-Gogs-Signature'] = hub_signature(payload)
+    request.headers['X-Gitea-Signature'] = gitea_signature(payload)
+    request.headers['X-Gogs-Signature'] = gitea_signature(payload)
     post(:event, payload)
 
     merge_request = MergeRequest.where(url: url).first
@@ -466,8 +466,8 @@ class MergeRequestsControllerTest < ActionController::TestCase
     request.headers['X-Gitea-Event'] = 'pull_request'
     request.headers['X-GitHub-Event'] = 'pull_request'
     request.headers['X-Gogs-Event'] = 'pull_request'
-    request.headers['X-Gitea-Signature'] = hub_signature(payload)
-    request.headers['X-Gogs-Signature'] = hub_signature(payload)
+    request.headers['X-Gitea-Signature'] = gitea_signature(payload)
+    request.headers['X-Gogs-Signature'] = gitea_signature(payload)
     post(:event, payload)
 
     merge_request = MergeRequest.where(url: url).first
@@ -497,8 +497,8 @@ class MergeRequestsControllerTest < ActionController::TestCase
     request.headers['X-Gitea-Event'] = 'pull_request'
     request.headers['X-GitHub-Event'] = 'pull_request'
     request.headers['X-Gogs-Event'] = 'pull_request'
-    request.headers['X-Gitea-Signature'] = hub_signature(payload)
-    request.headers['X-Gogs-Signature'] = hub_signature(payload)
+    request.headers['X-Gitea-Signature'] = gitea_signature(payload)
+    request.headers['X-Gogs-Signature'] = gitea_signature(payload)
     post(:event, payload)
 
     assert_response :success
@@ -517,6 +517,12 @@ class MergeRequestsControllerTest < ActionController::TestCase
 
   def hub_signature(payload)
     'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'),
+                                      TOKEN,
+                                      payload.to_query)
+  end
+
+  def gitea_signature(payload)
+    'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'),
                                       TOKEN,
                                       payload.to_query)
   end

--- a/test/functional/merge_requests_controller_test.rb
+++ b/test/functional/merge_requests_controller_test.rb
@@ -10,9 +10,9 @@ class MergeRequestsControllerTest < ActionController::TestCase
 
   def setup
     RedmineMergeRequestLinks.event_handlers = [
+      RedmineMergeRequestLinks::EventHandlers::Gitea.new(token: TOKEN),
       RedmineMergeRequestLinks::EventHandlers::Github.new(token: TOKEN),
-      RedmineMergeRequestLinks::EventHandlers::Gitlab.new(token: TOKEN),
-      RedmineMergeRequestLinks::EventHandlers::Gitea.new(token: TOKEN)
+      RedmineMergeRequestLinks::EventHandlers::Gitlab.new(token: TOKEN)
     ]
   end
 
@@ -369,7 +369,11 @@ class MergeRequestsControllerTest < ActionController::TestCase
       }
     }
     request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-GitHub-Event'] = 'pull_request'
+    request.headers['X-Gogs-Event'] = 'pull_request'
     request.headers['X-Gitea-Signature'] = hub_signature(payload)
+    request.headers['X-Gogs-Signature'] = hub_signature(payload)
+
     post(:event, payload)
 
     assert_response :success
@@ -386,6 +390,8 @@ class MergeRequestsControllerTest < ActionController::TestCase
   def test_responds_with_forbidden_if_gitea_signature_is_incorrect
     request.headers['X-Gitea-Event'] = 'pull_request'
     request.headers['X-Gitea-Signature'] = 'wrong'
+    request.headers['X-Gogs-Event'] = 'pull_request'
+    request.headers['X-Gogs-Signature'] = 'wrong'
     post(:event, pull_request: {
            html_url: 'https://gitea.com/Codertocat/Hello-World/pull/1',
            title: 'Some pull request',
@@ -426,7 +432,10 @@ class MergeRequestsControllerTest < ActionController::TestCase
       }
     }
     request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-GitHub-Event'] = 'pull_request'
+    request.headers['X-Gogs-Event'] = 'pull_request'
     request.headers['X-Gitea-Signature'] = hub_signature(payload)
+    request.headers['X-Gogs-Signature'] = hub_signature(payload)
     post(:event, payload)
 
     merge_request = MergeRequest.where(url: url).first
@@ -455,7 +464,10 @@ class MergeRequestsControllerTest < ActionController::TestCase
       }
     }
     request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-GitHub-Event'] = 'pull_request'
+    request.headers['X-Gogs-Event'] = 'pull_request'
     request.headers['X-Gitea-Signature'] = hub_signature(payload)
+    request.headers['X-Gogs-Signature'] = hub_signature(payload)
     post(:event, payload)
 
     merge_request = MergeRequest.where(url: url).first
@@ -483,7 +495,10 @@ class MergeRequestsControllerTest < ActionController::TestCase
       }
     }
     request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-GitHub-Event'] = 'pull_request'
+    request.headers['X-Gogs-Event'] = 'pull_request'
     request.headers['X-Gitea-Signature'] = hub_signature(payload)
+    request.headers['X-Gogs-Signature'] = hub_signature(payload)
     post(:event, payload)
 
     assert_response :success

--- a/test/functional/merge_requests_controller_test.rb
+++ b/test/functional/merge_requests_controller_test.rb
@@ -11,7 +11,8 @@ class MergeRequestsControllerTest < ActionController::TestCase
   def setup
     RedmineMergeRequestLinks.event_handlers = [
       RedmineMergeRequestLinks::EventHandlers::Github.new(token: TOKEN),
-      RedmineMergeRequestLinks::EventHandlers::Gitlab.new(token: TOKEN)
+      RedmineMergeRequestLinks::EventHandlers::Gitlab.new(token: TOKEN),
+      RedmineMergeRequestLinks::EventHandlers::Gitea.new(token: TOKEN)
     ]
   end
 

--- a/test/functional/merge_requests_controller_test.rb
+++ b/test/functional/merge_requests_controller_test.rb
@@ -368,6 +368,7 @@ class MergeRequestsControllerTest < ActionController::TestCase
       }
     }
     request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-Gitea-Signature'] = hub_signature(payload)
     post(:event, payload)
 
     assert_response :success
@@ -424,6 +425,7 @@ class MergeRequestsControllerTest < ActionController::TestCase
       }
     }
     request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-Gitea-Signature'] = hub_signature(payload)
     post(:event, payload)
 
     merge_request = MergeRequest.where(url: url).first
@@ -452,6 +454,7 @@ class MergeRequestsControllerTest < ActionController::TestCase
       }
     }
     request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-Gitea-Signature'] = hub_signature(payload)
     post(:event, payload)
 
     merge_request = MergeRequest.where(url: url).first
@@ -479,6 +482,7 @@ class MergeRequestsControllerTest < ActionController::TestCase
       }
     }
     request.headers['X-Gitea-Event'] = 'pull_request'
+    request.headers['X-Gitea-Signature'] = hub_signature(payload)
     post(:event, payload)
 
     assert_response :success


### PR DESCRIPTION
Resolves #16 

Gitea (currently) uses the same format as GitHub and provides (almost) all informations as GitHub.
In fact it does provide `X-GitHub-*` headers but no GitHub signature.

The signature provided via `X-Gitea-Signature` is hashed via SHA256.