### PR TITLE
added patch for 5.0 and modified init.rb and lib/redmine_merge_reques…

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -15,4 +15,4 @@ Redmine::Plugin.register :redmine_merge_request_links do
   end
 end
 
-require 'redmine_merge_request_links'
+require File.expand_path('../lib/redmine_merge_request_links', __FILE__)

--- a/lib/redmine_merge_request_links.rb
+++ b/lib/redmine_merge_request_links.rb
@@ -1,7 +1,7 @@
-require 'redmine_merge_request_links/hooks'
-require 'redmine_merge_request_links/patches/issue_patch'
-require 'redmine_merge_request_links/patches/issue_query_patch'
-require 'redmine_merge_request_links/patches/queries_helper_patch'
+require File.expand_path('../../lib/redmine_merge_request_links/hooks', __FILE__)
+require File.expand_path('../../lib/redmine_merge_request_links/patches/issue_patch', __FILE__)
+require File.expand_path('../../lib/redmine_merge_request_links/patches/issue_query_patch', __FILE__)
+require File.expand_path('../../lib/redmine_merge_request_links/patches/queries_helper_patch', __FILE__)
 
 module RedmineMergeRequestLinks
   github_token = ENV['REDMINE_MERGE_REQUEST_LINKS_GITHUB_WEBHOOK_TOKEN']

--- a/patches/view_hook_issues_show_after_details_redmine_5.0.patch
+++ b/patches/view_hook_issues_show_after_details_redmine_5.0.patch
@@ -1,0 +1,13 @@
+diff --git a/app/views/issues/show.html.erb b/app/views/issues/show.html.erb
+index 6a948b6..8a07351 100644
+--- a/app/views/issues/show.html.erb
++++ b/app/views/issues/show.html.erb
+@@ -121,6 +121,8 @@ end %>
+
+ <%= render partial: 'action_menu_edit' if User.current.wants_comments_in_reverse_order? %>
+
++<%= call_hook(:view_issues_show_after_details, :issue => @issue) %>
++
+ <div id="history">
+ <%= render_tabs issue_history_tabs, issue_history_default_tab %>
+ </div>


### PR DESCRIPTION
- Created patch for redmine 5.0 and modified init.rb and lib/redmine_merge_request_links.rb to support Redmine 5 (Rails 6)
- Stylesheet redmine_merge_request_links.css will need some adjusting so that the div corresponding to the merge requests can blend into the redmine 5.0 page structure more seamlessly